### PR TITLE
Make exp_with_args.sh agnostic to hard coded vars

### DIFF
--- a/sh/exp_with_args.sh
+++ b/sh/exp_with_args.sh
@@ -1,4 +1,5 @@
-WORKDIR="path_to_your_dir/CodeT5"
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+WORKDIR="${SCRIPT_DIR}/.."
 export PYTHONPATH=$WORKDIR
 
 TASK=${1}


### PR DESCRIPTION
Automatic determination of the CodeT5 directory based on the parent of the directory the script resides in